### PR TITLE
don't omit function params that evaluate to false (like 0)

### DIFF
--- a/views/main.js
+++ b/views/main.js
@@ -32,7 +32,13 @@ function exampleTabView (state, emit) {
 
     let functionName;
     if (obj.inputs !== undefined) {
-      functionName = `${obj.name}( ${obj.inputs.map((input) => `${input.name}${input.default ? ` = ${input.default}`: ''}`).join(', ')} )`
+        let params = obj.inputs.map((input) =>
+            input.default === undefined
+                ? input.name
+                : `${input.name}=${input.default}`
+        );
+        params = params.join(', ');
+      functionName = `${obj.name}( ${params} )`
     }
     else {
       if (obj.default !== undefined) {


### PR DESCRIPTION
I found it confusing when looking at the function list and some parameters had their default values omitted, for example with `repeat`, offsetX and offsetY have no default value shown

![defaults-missing](https://github.com/hydra-synth/hydra-functions/assets/975066/affaf71a-d472-493c-9193-723f1ba0a69e)

this change ensures that default values like 0, false or null will be shown in the codeblock.