### PR TITLE
Render the type of input variables in the docs

### DIFF
--- a/views/main.js
+++ b/views/main.js
@@ -32,7 +32,7 @@ function exampleTabView (state, emit) {
 
     let functionName;
     if (obj.inputs !== undefined) {
-      functionName = `${obj.name}( ${obj.inputs.map((input) => `${input.name}${input.type ? `: ${input.type}`: ''}${input.default ? ` = ${input.default}`: ''}`).join(', ')} )`
+      functionName = `${obj.name}( ${obj.inputs.map((input) => `${input.name}${input.type ? `: ${input.type}`: ''}${input.default !== undefined ? ` = ${input.default}`: ''}`).join(', ')} )`
     }
     else {
       if (obj.default !== undefined) {

--- a/views/main.js
+++ b/views/main.js
@@ -32,7 +32,7 @@ function exampleTabView (state, emit) {
 
     let functionName;
     if (obj.inputs !== undefined) {
-      functionName = `${obj.name}( ${obj.inputs.map((input) => `${input.name}${input.default ? ` = ${input.default}`: ''}`).join(', ')} )`
+      functionName = `${obj.name}( ${obj.inputs.map((input) => `${input.name}${input.type ? `: ${input.type}`: ''}${input.default ? ` = ${input.default}`: ''}`).join(', ')} )`
     }
     else {
       if (obj.default !== undefined) {


### PR DESCRIPTION
While browsing the Hydra functions, I often look at the "Usage" first and wonder what the different input types are. 
I then also found out that these are actually defined in the `glsl-functions.js` file, but not used in the docs.

This PR now renders the type information also in the documentation and therefore provide better information for the user.
It also updates the logic to display default values to not ignore `0` and empty values.

![image](https://github.com/user-attachments/assets/3d3900b8-aad3-49be-aa4d-d1af0e73d8e8)
